### PR TITLE
Added awsume console plugin useful for generating links to the console

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ ENV PATH=/root/.local/bin:$PATH
 # awsume won't set AWS_* env variables when installed via pip
 RUN pipx install awscli \
     && pipx install awsume \
+    && pipx inject awsume awsume-console-plugin \
     && awsume-configure --shell bash --autocomplete-file ~/.bashrc --alias-file ~/.bashrc
 
 ENTRYPOINT ["bash"]

--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ export AWS_DEFAULT_REGION=eu-central-1
 export AWSUME_PROFILE=dev
 ```
 
+### Use the awsume console plugin to generate a url to the console
+Related docs: https://github.com/trek10inc/awsume-console-plugin
+```
+host> docker run --rm -it -v ~/.aws:/root/.aws/ gesellix/awsume # run the container's shell
+
+> awsume dev -cl
+> awsume dev -csl cfn # go directly to cloudformation
+```
+
+
 ## Build the Docker image
 
 If you want to change the Docker image for your specific needs, you'll need to change the relevant files, e.g. `Dockerfile`, and rebuild the image:

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Related docs: https://github.com/trek10inc/awsume-console-plugin
 ```
 host> docker run --rm -it -v ~/.aws:/root/.aws/ gesellix/awsume # run the container's shell
 
-> awsume dev -cl
-> awsume dev -csl cfn # go directly to cloudformation
+> awsume <profile> -cl
+> awsume <profile> -csl cfn # go directly to cloudformation
 ```
 
 


### PR DESCRIPTION
Since this is in a container, theres no simple way to get the awsume console plugin to launch Google Chrome.  However, you can at least use this plugin to generate links to the console that can be command-clicked.